### PR TITLE
Update pagerduty-icinga2.conf

### DIFF
--- a/pagerduty-icinga2.conf
+++ b/pagerduty-icinga2.conf
@@ -8,7 +8,7 @@ object User "pagerduty" {
 
 object NotificationCommand "notify-service-by-pagerduty" {
   import "plugin-notification-command"
-  command = "/usr/local/bin/pagerduty_icinga.pl"
+  command = [ "/usr/local/bin/pagerduty_icinga.pl" ]
   arguments = {
     "enqueue" = {
       skip_key = true
@@ -34,7 +34,7 @@ object NotificationCommand "notify-service-by-pagerduty" {
 
 object NotificationCommand "notify-host-by-pagerduty" {
   import "plugin-notification-command"
-  command = "/usr/local/bin/pagerduty_icinga.pl"
+  command = [ "/usr/local/bin/pagerduty_icinga.pl" ]
   arguments = {
     "enqueue" = {
       skip_key = true


### PR DESCRIPTION
Per [this ticket](https://pagerduty.zendesk.com/agent/tickets/64626) it looks like Icinga made an update where any objects in config files that have arguments need to have commands in an array. I tested this myself and confirmed the error. This PR should clear it up so that the config file works by default.
