### PR TITLE
create custom usergroup for pagerduty user

### DIFF
--- a/pagerduty-icinga2.conf
+++ b/pagerduty-icinga2.conf
@@ -1,9 +1,13 @@
 object User "pagerduty" {
   pager = "SERVICE_API_KEY_HERE"
-  groups = [ "icingaadmins" ]
+  groups = [ "pagerdutyadmins" ]
   display_name = "PagerDuty Notification User"
   states = [ OK, Warning, Critical, Unknown, Up, Down ]
   types = [ Problem, Acknowledgement, Recovery ]
+}
+
+object UserGroup "pagerdutyadmins" {
+  display_name = "Icinga 2 PagerDuty Admin Group"
 }
 
 object NotificationCommand "notify-service-by-pagerduty" {


### PR DESCRIPTION
in case the default icingaadmins user group is used to send email then errors are generated for notifications generated for pagerduty.

more info: https://github.com/Icinga/icinga2/issues/5684